### PR TITLE
Zeitwerk support

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,8 +1,9 @@
 require 'redmine'
-require_dependency 'redmine_extended_reminder/hooks'
+require_dependency File.expand_path('../lib/redmine_extended_reminder/hooks', __FILE__)
 
-Rails.configuration.to_prepare do
-  require_dependency 'redmine_extended_reminder/mailer_model_patch'
+zeitwerk_enabled = Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
+Rails.configuration.__send__(zeitwerk_enabled ? :after_initialize : :to_prepare) do
+  require_dependency File.expand_path('../lib/redmine_extended_reminder/mailer_model_patch', __FILE__)
 end
 
 Redmine::Plugin.register :redmine_extended_reminder do


### PR DESCRIPTION
When I tried to run this plugin with Redmine's trunk branch([r21444](https://www.redmine.org/projects/redmine/repository/revisions/21444)), the execution of `bundle exec rake db:create` failed.
```
rake aborted!
LoadError: cannot load such file -- redmine_extended_reminder/hooks
/tmp/redmine/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
/tmp/redmine/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
/tmp/redmine/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.4.6/lib/active_support/dependencies/zeitwerk_integration.rb:51:in `require_dependency'
/tmp/redmine/plugins/redmine_extended_reminder/init.rb:2:in `<top (required)>'
```

I fixed to work with the trunk and the following versions of Redmine.
* trunk([r21444](https://www.redmine.org/projects/redmine/repository/revisions/21444))
* 4.2-stable([r21431](https://www.redmine.org/projects/redmine/repository/revisions/21431))
* 4.1-stable([r21432](https://www.redmine.org/projects/redmine/repository/revisions/21432))
* 4.0-stable([r20977](https://www.redmine.org/projects/redmine/repository/revisions/20977))
* 3.4-stable([r19398](https://www.redmine.org/projects/redmine/repository/revisions/19398))
