### PR TITLE
Improve value of pass 'checked' argument to check_box_tag method

### DIFF
--- a/app/views/redmine_extended_reminder/_plugin_settings.html.haml
+++ b/app/views/redmine_extended_reminder/_plugin_settings.html.haml
@@ -11,7 +11,7 @@
   %p
     %label{:for => 'settings_disable_on_non_woking_days'}
       = l(:extended_reminder_disable_on_non_woking_days)
-    = check_box_tag 'settings[disable_on_non_woking_days]', 1, @settings['disable_on_non_woking_days']
+    = check_box_tag 'settings[disable_on_non_woking_days]', 1, (@settings['disable_on_non_woking_days'].to_i != 0)
     %br
     %em.info
       = l(:extended_reminder_info_disable_on_non_woking_days)


### PR DESCRIPTION
The initial settings immediately after installing the plugin are as shown below, but if you look at the settings screen, you will see that "Disable on non-working days" is checked.

I fixed the value of the third argument in the check_box_tag method.

ref. https://github.com/rails/rails/blob/v7.1.2/actionview/lib/action_view/helpers/form_tag_helper.rb#L462

https://github.com/vividtone/redmine_extended_reminder/blob/5f4b426c887330b2daef2515430c1f29f6ee5390/init.rb#L18-L20

<kbd>
<img width="868" alt="ScreenShot 2024-06-04 14 13 29" src="https://github.com/vividtone/redmine_extended_reminder/assets/7232538/d951635b-9af5-4152-8879-b31d798c4191">
</kbd>
